### PR TITLE
Use structopt for cli options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env
+completions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1185,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.67",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1601,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.67",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,11 +1905,11 @@ dependencies = [
 name = "twitchctl"
 version = "0.1.0"
 dependencies = [
- "clap",
  "derivative",
  "derive-error",
  "dotenv",
  "fuzzy-filter",
+ "structopt",
  "surf",
  "tokio",
  "twitch_api2",
@@ -1902,6 +1959,12 @@ checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
 derivative = "2.2.0"
 derive-error = "0.0.5"
 dotenv = "0.15.0"
 fuzzy-filter = "0.1.0"
+structopt = "0.3.21"
 surf = "2.2.0"
 tokio = {version="1.4.0",features=["full"]}
 twitch_api2 = {git = "https://github.com/Emilgardis/twitch_api2", features= ["helix", "client", "surf"]}

--- a/src/api.rs
+++ b/src/api.rs
@@ -41,7 +41,7 @@ impl<'a> ApiClient<'a> {
     pub async fn search_categories(
         &self,
         term: String,
-        max: Option<usize>,
+        max: usize,
     ) -> Result<Option<Vec<Category>>, Box<dyn Error>> {
         // TODO Implement some better filter (only starting with for example) to reduce the number
         // of results for searches
@@ -52,7 +52,7 @@ impl<'a> ApiClient<'a> {
 
         let req = SearchCategoriesRequest::builder()
             .query(term)
-            .first(max.unwrap_or(20).max(1).min(100).to_string())
+            .first(max.max(1).min(100).to_string())
             .build();
         let res: Vec<Category> = self.helix_client.req_get(req, &self.token).await?.data;
         if res.len() > 0 {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use crate::tags::TagsOptions;
 
 /// A sane Twitch commandline interface
 #[derive(Debug, StructOpt)]
-#[structopt(name = "twitchctl", version = env!("CARGO_PKG_VERSION"))]
+#[structopt(name = "twitchctl")]
 pub struct CliOptions {
     #[structopt(subcommand)]
     pub category: Category,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,35 +3,41 @@ use std::{path::PathBuf, str::FromStr};
 use structopt::{clap::Shell, StructOpt};
 use crate::tags::TagsOptions;
 
-#[derive(StructOpt)]
-#[structopt(name = "basic", about = "A sane Twitch commandline interface", version = "0.1.0")]
+/// A sane Twitch commandline interface
+#[derive(Debug, StructOpt)]
+#[structopt(name = "twitchctl", version = env!("CARGO_PKG_VERSION"))]
 pub struct CliOptions {
     #[structopt(subcommand)]
     pub category: Category,
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, StructOpt)]
 pub enum Category {
-    #[structopt(about = "show all tags or tags for a specific broadcaster")]
+    /// show all tags or tags for a specific broadcaster
     Tags { 
         #[structopt(flatten)]
         options: TagsOptions,
     },
-    #[structopt(about = "searches in categories")]
+    /// searches in categories
     Search {
+        /// max amount of results to show
         #[structopt(short, long, default_value = "20")]
         max_results: usize,
+        /// the category in which to search
         category: String,
     },
-    #[structopt(about = "creates a file containing shell completions")]
+    /// creates a file containing shell completions
     Completions {
-        #[structopt(short, long, default_value = "completions", help = "in which directory the completion file will be written")]
+        /// the directory to write the completion file to
+        #[structopt(short, long, default_value = "completions")]
         target_dir: PathBuf,
-        #[structopt(help = "the shell for which the completions should be generated. (Currently supported values: bash, fish, zsh, powershell, elvish)")]
+        /// the shell for which the completions should be generated.
+        /// (currently supported values: bash, fish, zsh, powershell, elvish)
         shell: ShellType,
     },
 }
 
+#[derive(Debug)]
 pub enum ShellType {
     Bash,
     Fish,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,21 +7,27 @@ use crate::tags::TagsOptions;
 #[structopt(name = "basic", about = "A sane Twitch commandline interface", version = "0.1.0")]
 pub struct CliOptions {
     #[structopt(subcommand)]
-    pub subcommand: SubCommand,
+    pub category: Category,
 }
 
 #[derive(StructOpt)]
-pub enum SubCommand {
+pub enum Category {
+    #[structopt(about = "show all tags or tags for a specific broadcaster")]
     Tags { 
         #[structopt(flatten)]
         options: TagsOptions,
     },
     #[structopt(about = "searches in categories")]
-    SearchCategories,
+    Search {
+        #[structopt(short, long, default_value = "20")]
+        max_results: usize,
+        category: String,
+    },
     #[structopt(about = "creates a file containing shell completions")]
     Completions {
-        #[structopt(short, long, default_value = "completions")]
+        #[structopt(short, long, default_value = "completions", help = "in which directory the completion file will be written")]
         target_dir: PathBuf,
+        #[structopt(help = "the shell for which the completions should be generated. (Currently supported values: bash, fish, zsh, powershell, elvish)")]
         shell: ShellType,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,62 @@
+use std::{path::PathBuf, str::FromStr};
+
+use structopt::{clap::Shell, StructOpt};
+use crate::tags::TagsOptions;
+
+#[derive(StructOpt)]
+#[structopt(name = "basic", about = "A sane Twitch commandline interface", version = "0.1.0")]
+pub struct CliOptions {
+    #[structopt(subcommand)]
+    pub subcommand: SubCommand,
+}
+
+#[derive(StructOpt)]
+pub enum SubCommand {
+    Tags { 
+        #[structopt(flatten)]
+        options: TagsOptions,
+    },
+    #[structopt(about = "searches in categories")]
+    SearchCategories,
+    #[structopt(about = "creates a file containing shell completions")]
+    Completions {
+        #[structopt(short, long, default_value = "completions")]
+        target_dir: PathBuf,
+        shell: ShellType,
+    },
+}
+
+pub enum ShellType {
+    Bash,
+    Fish,
+    Zsh,
+    PowerShell,
+    Elvish,
+}
+
+impl FromStr for ShellType {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bash" => Ok(ShellType::Bash),
+            "fish" => Ok(ShellType::Fish),
+            "zsh" => Ok(ShellType::Zsh),
+            "powershell" => Ok(ShellType::PowerShell),
+            "elvish" => Ok(ShellType::Elvish),
+            _ => Err("unsupported shell"),
+        }
+    }
+}
+
+impl Into<Shell> for &ShellType {
+    fn into(self) -> Shell { 
+        match self {
+            ShellType::Bash => Shell::Bash,
+            ShellType::Fish => Shell::Fish,
+            ShellType::Zsh  => Shell::Zsh,
+            ShellType::PowerShell => Shell::PowerShell,
+            ShellType::Elvish => Shell::Elvish,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::fs::create_dir_all(target_dir)?;
         }
         CliOptions::clap().gen_completions(env!("CARGO_PKG_NAME"), shell.into(), target_dir);
+        println!("Completions file has been written to the directory: {}", target_dir.to_string_lossy());
         return Ok(());
     }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -3,37 +3,39 @@ use structopt::StructOpt;
 use fuzzy_filter::FuzzyFilter;
 use twitch_api2::helix::tags::TwitchTag;
 
-#[derive(StructOpt)]
-#[structopt(about = "manipulate a streams tags")]
+#[derive(Debug, StructOpt)]
+/// manipulate a streams tags
 pub struct TagsOptions {
-    #[structopt(short = "i", long, default_value = "en-us", help = "the locale to use for the tag names")]
+    /// the locale to use for the tag names
+    #[structopt(short, long, default_value = "en-us")]
     pub locale: String,
 
     #[structopt(subcommand)]
     pub subcommand: TagsSubcommand,
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, StructOpt)]
 pub enum TagsSubcommand {
-    #[structopt(about = "list all tags")]
+    /// list all available tags
     ListAll {
         #[structopt(flatten)]
         shared: SharedTagsOptions,
     },
-    #[structopt(about = "list tags for a broadcaster")]
+    /// list tags for a broadcaster
     List {
-        #[structopt(help = "the name of the broadcaster for which to list the tags")]
+        /// the name of the broadcaster for which to list the tags
         broadcaster: String,
         #[structopt(flatten)]
         shared: SharedTagsOptions,
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, StructOpt)]
 pub struct SharedTagsOptions {
-    #[structopt(short, help = "print tags in long format")]
+    /// print tags in long format
+    #[structopt(short)]
     long: bool,
-    #[structopt(help = "string for fuzzy filtering of tags")]
+    /// string for fuzzy filtering of tags
     filter: Option<String>,
 }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,76 +1,63 @@
 use super::api::ApiClient;
-use clap::{App, Arg, ArgMatches};
+use structopt::StructOpt;
 use fuzzy_filter::FuzzyFilter;
 use twitch_api2::helix::tags::TwitchTag;
 
-pub fn get_tags_app<'a>() -> App<'a, 'a> {
-    App::new("tags")
-        .about("manipulate a streams tags")
-        .arg(
-            Arg::with_name("locale")
-                .short("i")
-                .long("locale")
-                .default_value("en-us"),
-        )
-        .subcommand(
-            App::new("listall")
-                .arg(
-                    Arg::with_name("long")
-                        .short("l")
-                        .help("use a long listing format"),
-                )
-                .arg(
-                    Arg::with_name("needle")
-                        .index(1)
-                        .help("filter tags with a fuzzy search"),
-                ),
-        )
-        .subcommand(
-            App::new("list")
-                .arg(
-                    Arg::with_name("long")
-                        .short("l")
-                        .help("use a long listing format"),
-                )
-                .arg(
-                    Arg::with_name("broadcaster")
-                        .index(1)
-                        .required(true)
-                        .help("the broadcaster you want to fetch tags for"),
-                        //TODO default to the one running this command
-                )
-                .arg(
-                    Arg::with_name("needle")
-                        .index(2)
-                        .help("filter tags with a fuzzy search"),
-                ),
-        )
+#[derive(StructOpt)]
+#[structopt(about = "manipulate a streams tags")]
+pub struct TagsOptions {
+    #[structopt(short = "i", long, default_value = "en-us")]
+    pub locale: String,
+
+    #[structopt(subcommand)]
+    pub subcommand: TagsSubcommand,
 }
 
-pub async fn tags<'a>(client: ApiClient<'a>, matches: &ArgMatches<'a>) {
-    match matches.subcommand() {
-        ("listall", Some(sub_m)) => {
+#[derive(StructOpt)]
+pub enum TagsSubcommand {
+    ListAll {
+        #[structopt(flatten)]
+        shared: SharedTagsOptions,
+    },
+    List {
+        #[structopt(flatten)]
+        shared: SharedTagsOptions,
+        broadcaster: String,
+    },
+}
+
+#[derive(StructOpt)]
+pub struct SharedTagsOptions {
+    #[structopt(short)]
+    long: bool,
+    #[structopt(short, long)]
+    search_string: Option<String>,
+}
+
+pub async fn tags<'a>(client: ApiClient<'a>, locale: &str, command: TagsSubcommand) {
+    match command {
+        TagsSubcommand::ListAll { shared: SharedTagsOptions { long, search_string: needle } } => {
             let tags = client.get_all_tags().await.expect("valid tags");
             list(
                 &tags,
-                matches.value_of("locale").unwrap(),
-                sub_m.value_of("needle"),
-                sub_m.is_present("long"),
+                locale,
+                needle.as_ref(),
+                long,
             )
         }
-        ("list", Some(sub_m)) => {
-            let tags = client.get_stream_tags(sub_m.value_of("broadcaster").unwrap().to_string()).await.expect("valid tags");
+        TagsSubcommand::List { shared: SharedTagsOptions { long, search_string: needle }, broadcaster } => {
+            let tags = client.get_stream_tags(broadcaster).await.expect("valid tags");
             list(
                 &tags,
-                matches.value_of("locale").unwrap(),
-                sub_m.value_of("needle"),
-                sub_m.is_present("long"),
+                locale,
+                needle.as_ref(),
+                long,
             )
         }
-        _ => {}
     }
 }
-fn list<'a>(tags: &[TwitchTag], locale: &'a str, needle: Option<&str>, long: bool) {
+
+fn list<'a>(tags: &[TwitchTag], locale: &'a str, needle: Option<&'a String>, long: bool) {
     let filter = if let Some(needle) = needle {
         FuzzyFilter::new(needle)
     } else {


### PR DESCRIPTION
This makes the cli handling more type safe and should simplify adding new arguments.

I also added the base support for generating shell completions. Currently it generates the completion files into a specified directory (default: ./completions). I currently haven't added any documentation for it, because i still want to do a few tests and improve the generation (e.g.: auto detect the correct directory for the chosen shell).